### PR TITLE
Radio buttons and selects now support data-hide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - 'node'
+
 cache:
   directories:
     - "travis_phantomjs"

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ var Toggler = {
     // Events fire on the select, but the options have toggling attributes
     if (target.tagName.match(/select/i)) {
       select = target
-      target = target.selectedOptions[0]
+      target = select.selectedOptions[0]
     }
 
     // Radio inputs and selects do not support toggling, so remove them

--- a/index.js
+++ b/index.js
@@ -205,7 +205,8 @@ var Toggler = {
       if (!radio.dataset.togglerActive) {
         var radioName = radio.getAttribute('name')
         var siblings = Toggler.parentForm(radio).querySelectorAll('[type=radio][name="'+radioName+'"]')
-        var hideSelectors = Toggler.dataAttributes(siblings, 'show')
+
+        var showSelectors = Toggler.dataAttributes(siblings, 'show')
         var removeSelectors = Toggler.dataAttributes(siblings, 'addClass')
 
         Array.prototype.forEach.call(siblings, function(r){
@@ -215,8 +216,12 @@ var Toggler = {
           r.dataset.show = r.dataset.show || ''
           r.dataset.addClass = r.dataset.addClass || ''
 
-          r.dataset.hide = hideSelectors.filter(function(selector){
-            return r.dataset.show != selector
+          // Append element's data-hide to showSelectors
+          if ( r.dataset.hide && r.dataset.hide.length > 0 )
+            showSelectors = showSelectors.concat( r.dataset.hide.split( ',' ) )
+
+          r.dataset.hide = showSelectors.filter(function(selector){
+            return r.dataset.show.indexOf( selector )
           }).join(',')
 
           // Ensure that all radio buttons in a group have a default data-add-class value of ''
@@ -227,7 +232,7 @@ var Toggler = {
           // Ensure that selected radio buttons remove classes according
           // to the deselected radio buttons
           r.dataset.removeClass = removeSelectors.filter(function(selector){
-            return r.dataset.addClass != selector
+            return r.dataset.addClass.indexOf( selector )
           }).join('&')
 
 
@@ -254,19 +259,25 @@ var Toggler = {
         select.classList.add('select-toggler')
         var options = select.querySelectorAll('option')
 
-        var hideSelectors = Toggler.dataAttributes(options, 'show')
+        var showSelectors   = Toggler.dataAttributes(options, 'show')
         var removeSelectors = Toggler.dataAttributes(options, 'addClass')
 
         Array.prototype.forEach.call(options, function(o) {
           o.dataset.show = o.dataset.show || ''
           o.dataset.addClass = o.dataset.addClass || ''
 
-          o.dataset.hide = hideSelectors.filter(function(selector){
-            return o.dataset.show != selector
+          // Append element's data-hide to showSelectors
+          if ( o.dataset.hide && o.dataset.hide.length > 0 )
+            showSelectors = showSelectors.concat( o.dataset.hide.split( ',' ) )
+
+          // If show selectors are not present in element's data-show
+          // Add them to the list of selectors to be hidden
+          o.dataset.hide = showSelectors.filter(function(selector){
+            return o.dataset.show.indexOf( selector )
           }).join(',')
 
           o.dataset.removeClass = removeSelectors.filter(function(selector){
-            return o.dataset.addClass != selector
+            return o.dataset.addClass.indexOf( selector )
           }).join(' & ')
 
           o.dataset.togglerActive = true

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -177,6 +177,7 @@ describe('Toggler', function(){
       assert.isTrue(visible($('.panel-one')))
       assert.isTrue(!visible($('.panel-two')))
       assert.isTrue(!visible($('.panel-three')))
+      assert.isTrue(!visible($('.hide-test')))
     })
 
     it('shows only the second when two is selected', function(){
@@ -232,6 +233,7 @@ describe('Toggler', function(){
       assert.isTrue(!visible($('.panel-one')))
       assert.isTrue(visible($('.panel-two')))
       assert.isTrue(!visible($('.panel-three')))
+      assert.isTrue(!visible($('.hide-test')))
     })
 
     it('should hide all panels when none is selected', function(){

--- a/test/templates/radio.html
+++ b/test/templates/radio.html
@@ -1,6 +1,6 @@
 <form class='radios'>
   <input type='radio' class='none'  name='test-radio'>
-  <input type='radio' class='one'   name='test-radio'  data-show='.panel-one' data-add-class='one; .panels'>
+  <input type='radio' class='one'   name='test-radio'  data-show='.panel-one' data-hide='.hide-test' data-add-class='one; .panels'>
   <input type='radio' class='two'   name='test-radio'  data-show='.panel-two' data-add-class='two; .panels' checked='true'>
   <input type='radio' class='three' name='test-radio'  data-show='.panel-three' data-add-class='three; .panels'>
 </form>
@@ -12,3 +12,4 @@
 </div>
 
 <input type='radio' class='other-radio' name='test-radio'>
+<div class='hide-test'></div>

--- a/test/templates/select.html
+++ b/test/templates/select.html
@@ -1,8 +1,8 @@
 <select class='select-toggle'>
   <option data-add-class='none'>none</option>
-  <option data-show='.panel-one' data-add-class='one & one; .panels'>one</option>
-  <option data-show='.panel-two' data-add-class='two & two; .panels' selected>two</option>
-  <option data-show='.panel-three' data-add-class='three & three; .panels'>three</option>
+  <option data-show='.panel-one' data-hide='.hide-test' data-add-class='one & one; .panels'>one</option>
+  <option data-show='.panel-two' data-hide='.hide-test' data-add-class='two & two; .panels' selected>two</option>
+  <option data-show='.panel-three' data-hide='.hide-test' data-add-class='three & three; .panels'>three</option>
 </select>
 
 <div class='panels'>
@@ -10,3 +10,5 @@
   <div class='panel-two'></div>
   <div class='panel-three'></div>
 </div>
+
+<div class='hide-test'></div>


### PR DESCRIPTION
Now a select or radio button can force hide elements any time it is selected by adding selectors `data-hide`. This doesn't work like data-show, where it is exclusive based on other element's data-show. It will hide that element every time it is selected.